### PR TITLE
Performance research

### DIFF
--- a/src/gRPC_MMO/client/Services/ConnectionManager.cs
+++ b/src/gRPC_MMO/client/Services/ConnectionManager.cs
@@ -18,7 +18,7 @@ namespace MMOgRPC.Services
 
         private readonly GrpcChannel _channel;
         private readonly ProximityUpdater.ProximityUpdaterClient _client;
-        private readonly SynchronizationContext _syncContext;
+        private readonly SynchronizationContext? _syncContext;
 
         private Player _playerState = new();
         private DateTime _playerStateLastUpdate = DateTime.MinValue;
@@ -39,7 +39,7 @@ namespace MMOgRPC.Services
 
         public delegate void PlayersStateUpdatedEventHandler(Players players);
 
-        public event PlayersStateUpdatedEventHandler PlayersStateUpdated;
+        public event PlayersStateUpdatedEventHandler? PlayersStateUpdated;
 
 
         public static ConnectionManager Instance { get; set; } = new();

--- a/src/gRPC_MMO/server/ProximitySync/Data/IPlayerManager.cs
+++ b/src/gRPC_MMO/server/ProximitySync/Data/IPlayerManager.cs
@@ -1,0 +1,16 @@
+﻿
+namespace ProximitySync.Data
+{
+    public interface IPlayerManager
+    {
+        int Count { get; }
+
+        void AddPlayer(Player player);
+        void Clear();
+        bool Contains(Player player);
+        bool Contains(string playerName);
+        ICollection<Player> GetPlayers();
+        void RemovePlayer(string playerName);
+        void Update(Player request);
+    }
+}

--- a/src/gRPC_MMO/server/ProximitySync/Data/PlayerManager.cs
+++ b/src/gRPC_MMO/server/ProximitySync/Data/PlayerManager.cs
@@ -1,16 +1,14 @@
-using System.Collections.Concurrent;
+﻿using System.Collections.Concurrent;
 
 namespace ProximitySync.Data
 {
     public class PlayerManager : IPlayerManager
     {
-        public static readonly PlayerManager Instance = new();
-
         private readonly ConcurrentDictionary<string, Player> _players = [];
         private readonly ConcurrentDictionary<string, DateTime> _playersLastUpdate = [];
 
 
-        private PlayerManager()
+        public PlayerManager()
         {
             MonitorAndRemoveInactivePlayers(TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(10));
         }

--- a/src/gRPC_MMO/server/ProximitySync/Data/PlayerManager.cs
+++ b/src/gRPC_MMO/server/ProximitySync/Data/PlayerManager.cs
@@ -1,8 +1,8 @@
-﻿using System.Collections.Concurrent;
+using System.Collections.Concurrent;
 
 namespace ProximitySync.Data
 {
-    public class PlayerManager
+    public class PlayerManager : IPlayerManager
     {
         public static readonly PlayerManager Instance = new();
 

--- a/src/gRPC_MMO/server/ProximitySync/Data/PlayerManagerV2.cs
+++ b/src/gRPC_MMO/server/ProximitySync/Data/PlayerManagerV2.cs
@@ -1,4 +1,4 @@
-using System.Collections.Concurrent;
+﻿using System.Collections.Concurrent;
 
 namespace ProximitySync.Data
 {
@@ -9,8 +9,6 @@ namespace ProximitySync.Data
     /// </summary>
     public class PlayerManagerV2 : IPlayerManager
     {
-        public static readonly PlayerManagerV2 Instance = new();
-
         private readonly ReaderWriterLockSlim _lock = new();
         private readonly Dictionary<string, Player> _players = [];
 
@@ -18,7 +16,7 @@ namespace ProximitySync.Data
         //private readonly ConcurrentDictionary<string, DateTime> _playersLastUpdate = [];
 
 
-        private PlayerManagerV2()
+        public PlayerManagerV2()
         {
             //MonitorAndRemoveInactivePlayers(TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(10));
         }
@@ -36,7 +34,7 @@ namespace ProximitySync.Data
         }
 
 
-        public Player[] GetPlayers()
+        public ICollection<Player> GetPlayers()
         {
             _lock.EnterReadLock();
             var list = _players.Values.ToArray();

--- a/src/gRPC_MMO/server/ProximitySync/Data/PlayerManagerV2.cs
+++ b/src/gRPC_MMO/server/ProximitySync/Data/PlayerManagerV2.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Concurrent;
+using System.Collections.Concurrent;
 
 namespace ProximitySync.Data
 {
@@ -7,7 +7,7 @@ namespace ProximitySync.Data
     /// <summary>
     /// Note: This class is used to test if by changing ConcurrentDictionary with a custom implementation the amount of concurrent players to update will increase.
     /// </summary>
-    public class PlayerManagerV2
+    public class PlayerManagerV2 : IPlayerManager
     {
         public static readonly PlayerManagerV2 Instance = new();
 

--- a/src/gRPC_MMO/server/ProximitySync/Data/PlayerManagerV2.cs
+++ b/src/gRPC_MMO/server/ProximitySync/Data/PlayerManagerV2.cs
@@ -1,0 +1,125 @@
+﻿using System.Collections.Concurrent;
+
+namespace ProximitySync.Data
+{
+
+
+    /// <summary>
+    /// Note: This class is used to test if by changing ConcurrentDictionary with a custom implementation the amount of concurrent players to update will increase.
+    /// </summary>
+    public class PlayerManagerV2
+    {
+        public static readonly PlayerManagerV2 Instance = new();
+
+        private readonly ReaderWriterLockSlim _lock = new();
+        private readonly Dictionary<string, Player> _players = [];
+
+
+        //private readonly ConcurrentDictionary<string, DateTime> _playersLastUpdate = [];
+
+
+        private PlayerManagerV2()
+        {
+            //MonitorAndRemoveInactivePlayers(TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(10));
+        }
+
+
+        public int Count
+        {
+            get
+            {
+                _lock.EnterReadLock();
+                var c = _players.Count;
+                _lock.ExitReadLock();
+                return c;
+            }
+        }
+
+
+        public Player[] GetPlayers()
+        {
+            _lock.EnterReadLock();
+            var list = _players.Values.ToArray();
+            _lock.ExitReadLock();
+            return list;
+        }
+
+        /// <summary>
+        /// Adds or updates the player
+        /// </summary>
+        public void AddPlayer(Player player)
+        {
+            _lock.EnterWriteLock();
+            _players[player.Name] = player;
+            _lock.ExitWriteLock();
+
+            //_players.AddOrUpdate(player.Name, (string key) => player, (string key, Player p) => player);
+            //_playersLastUpdate[player.Name] = DateTime.Now;
+        }
+
+        public void RemovePlayer(string playerName)
+        {
+            _lock.EnterWriteLock();
+            _players.Remove(playerName);
+            _lock.ExitWriteLock();
+
+            //_players.TryRemove(playerName, out _);
+            //_playersLastUpdate.TryRemove(playerName, out _);
+        }
+
+        public bool Contains(Player player) => Contains(player.Name);
+
+        public bool Contains(string playerName)
+        {
+            _lock.EnterReadLock();
+            var b = _players.ContainsKey(playerName);
+            _lock.ExitReadLock();
+            return b;
+        }
+
+        /// <summary>
+        /// Updates or add the player
+        /// </summary>
+        public void Update(Player request)
+        {
+            _lock.EnterWriteLock();
+            _players[request.Name] = request;
+            _lock.ExitWriteLock();
+
+            //_players.AddOrUpdate(request.Name, request, (key, oldValue) => request);
+            //_playersLastUpdate[request.Name] = DateTime.Now;
+        }
+
+        public void Clear()
+        {
+            _lock.EnterWriteLock();
+            _players.Clear();
+            _lock.ExitWriteLock();
+        }
+
+        ///// <summary>
+        ///// Monitors and removes inactive players from the game.
+        ///// </summary>
+        ///// <param name="inactivityCheckInterval">The interval at which player activity is checked</param>
+        ///// <param name="inactivityThreshold">The duration of inactivity after which a player is considered inactive and removed</param>
+        //private void MonitorAndRemoveInactivePlayers(TimeSpan inactivityCheckInterval, TimeSpan inactivityThreshold)
+        //{
+        //    Task.Run(async () =>
+        //    {
+        //        DateTime currentTime;
+        //        while (true)
+        //        {
+        //            currentTime = DateTime.Now;
+        //            await Task.Delay(inactivityCheckInterval);
+        //            foreach (var playerUpdate in _playersLastUpdate)
+        //            {
+        //                if (currentTime - playerUpdate.Value > inactivityThreshold)
+        //                {
+        //                    RemovePlayer(playerUpdate.Key);
+        //                }
+        //            }
+        //        }
+        //    });
+        //}
+    }
+}

--- a/src/gRPC_MMO/server/ProximitySync/Data/PlayerManagerV3.cs
+++ b/src/gRPC_MMO/server/ProximitySync/Data/PlayerManagerV3.cs
@@ -1,0 +1,79 @@
+﻿using System.Collections.Concurrent;
+
+namespace ProximitySync.Data
+{
+
+
+    /// <summary>
+    /// Note: This class is used to test if by removing it's functionality and returning a static list every time.
+    /// </summary>
+    public class PlayerManagerV3
+    {
+        public static readonly PlayerManagerV3 Instance = new();
+
+        private readonly List<Player> _players = [];
+
+
+        //private readonly ConcurrentDictionary<string, DateTime> _playersLastUpdate = [];
+
+
+        private PlayerManagerV3()
+        {
+            for (int i = 0; i < 1000; i++)
+            {
+                _players.Add(new Player());
+            }
+            //MonitorAndRemoveInactivePlayers(TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(10));
+        }
+
+
+        public int Count { get => _players.Count; }
+
+
+        public List<Player> GetPlayers()
+        {
+            return _players;
+        }
+
+        /// <summary>
+        /// Adds or updates the player
+        /// </summary>
+        public void AddPlayer(Player player)
+        {
+
+            //_players.AddOrUpdate(player.Name, (string key) => player, (string key, Player p) => player);
+            //_playersLastUpdate[player.Name] = DateTime.Now;
+        }
+
+        public void RemovePlayer(string playerName)
+        {
+
+            //_players.TryRemove(playerName, out _);
+            //_playersLastUpdate.TryRemove(playerName, out _);
+        }
+
+        public bool Contains(Player player) => Contains(player.Name);
+
+        public bool Contains(string playerName)
+        {
+            return true;
+        }
+
+        /// <summary>
+        /// Updates or add the player
+        /// </summary>
+        public void Update(Player request)
+        {
+
+            //_players.AddOrUpdate(request.Name, request, (key, oldValue) => request);
+            //_playersLastUpdate[request.Name] = DateTime.Now;
+        }
+
+        public void Clear()
+        {
+            
+        }
+
+
+    }
+}

--- a/src/gRPC_MMO/server/ProximitySync/Data/PlayerManagerV3.cs
+++ b/src/gRPC_MMO/server/ProximitySync/Data/PlayerManagerV3.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Concurrent;
+using System.Collections.Concurrent;
 
 namespace ProximitySync.Data
 {
@@ -7,7 +7,7 @@ namespace ProximitySync.Data
     /// <summary>
     /// Note: This class is used to test if by removing it's functionality and returning a static list every time.
     /// </summary>
-    public class PlayerManagerV3
+    public class PlayerManagerV3 : IPlayerManager
     {
         public static readonly PlayerManagerV3 Instance = new();
 

--- a/src/gRPC_MMO/server/ProximitySync/Data/PlayerManagerV3.cs
+++ b/src/gRPC_MMO/server/ProximitySync/Data/PlayerManagerV3.cs
@@ -1,4 +1,4 @@
-using System.Collections.Concurrent;
+﻿using System.Collections.Concurrent;
 
 namespace ProximitySync.Data
 {
@@ -9,15 +9,13 @@ namespace ProximitySync.Data
     /// </summary>
     public class PlayerManagerV3 : IPlayerManager
     {
-        public static readonly PlayerManagerV3 Instance = new();
-
         private readonly List<Player> _players = [];
 
 
         //private readonly ConcurrentDictionary<string, DateTime> _playersLastUpdate = [];
 
 
-        private PlayerManagerV3()
+        public PlayerManagerV3()
         {
             for (int i = 0; i < 1000; i++)
             {
@@ -30,7 +28,7 @@ namespace ProximitySync.Data
         public int Count { get => _players.Count; }
 
 
-        public List<Player> GetPlayers()
+        public ICollection<Player> GetPlayers()
         {
             return _players;
         }

--- a/src/gRPC_MMO/server/ProximitySync/Program.cs
+++ b/src/gRPC_MMO/server/ProximitySync/Program.cs
@@ -1,13 +1,34 @@
+using ProximitySync.Data;
 using ProximitySync.Services;
+using ProximitySync.Services.V2;
 using System.Diagnostics;
 
-const int GRPC_IMPLEMENTATION_VERSION = 2;
 
+
+// CONFIG
+
+const int GRPC_IMPLEMENTATION_VERSION = 2;
+PlayerManager _pmVersion = new(); // can be changed to another implementation eg. PlayerManagerV3
+
+
+
+// APP
 
 var builder = WebApplication.CreateBuilder(args);
 
-// Add services to the container.
-builder.Services.AddGrpc();
+builder.Services.AddSingleton<IPlayerManager>(_pmVersion);
+if (GRPC_IMPLEMENTATION_VERSION == 2)
+{
+    builder.Services.AddSingleton<GameManager>();
+}
+
+builder.Services.AddGrpc(x =>
+{
+    x.EnableDetailedErrors = false;
+    x.MaxSendMessageSize = null;
+    x.MaxReceiveMessageSize = null;
+});
+
 
 var app = builder.Build();
 

--- a/src/gRPC_MMO/server/ProximitySync/Program.cs
+++ b/src/gRPC_MMO/server/ProximitySync/Program.cs
@@ -1,4 +1,8 @@
 using ProximitySync.Services;
+using System.Diagnostics;
+
+const int GRPC_IMPLEMENTATION_VERSION = 2;
+
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -8,7 +12,18 @@ builder.Services.AddGrpc();
 var app = builder.Build();
 
 // Configure the HTTP request pipeline.
-app.MapGrpcService<ProximityService>();
+#pragma warning disable CS0162 // Unreachable code detected
+if (GRPC_IMPLEMENTATION_VERSION == 1)
+{
+    app.MapGrpcService<ProximityService>();
+}
+else if (GRPC_IMPLEMENTATION_VERSION == 2)
+{
+    app.MapGrpcService<ProximityServiceV2>();
+}
+#pragma warning restore CS0162 // Unreachable code detected
+
+
 app.MapGet("/", () => "Communication with gRPC endpoints must be made through a gRPC client. To learn how to create a client, visit: https://go.microsoft.com/fwlink/?linkid=2086909");
 
 app.Run();

--- a/src/gRPC_MMO/server/ProximitySync/Services/ProximityService.cs
+++ b/src/gRPC_MMO/server/ProximitySync/Services/ProximityService.cs
@@ -6,9 +6,8 @@ using ProximitySync.Data;
 namespace ProximitySync.Services;
 
 
-public class ProximityService(ILogger<ProximityService> logger) : ProximityUpdater.ProximityUpdaterBase
+public class ProximityService(ILogger<ProximityService> logger, IPlayerManager _pm) : ProximityUpdater.ProximityUpdaterBase
 {
-    private readonly PlayerManager _pm = PlayerManager.Instance;
 
     public override async Task UpdatePlayers(Empty request, IServerStreamWriter<Players> responseStream, ServerCallContext context)
     {

--- a/src/gRPC_MMO/server/ProximitySync/Services/ProximityServiceV2.cs
+++ b/src/gRPC_MMO/server/ProximitySync/Services/ProximityServiceV2.cs
@@ -1,0 +1,38 @@
+using Google.Protobuf.WellKnownTypes;
+using Grpc.Core;
+using ProximitySync;
+using ProximitySync.Data;
+using ProximitySync.Services.V2;
+
+namespace ProximitySync.Services;
+
+
+public class ProximityServiceV2(ILogger<ProximityService> logger) : ProximityUpdater.ProximityUpdaterBase
+{
+    private readonly PlayerManager _pm = PlayerManager.Instance;
+
+    public override async Task UpdatePlayers(Empty request, IServerStreamWriter<Players> responseStream, ServerCallContext context)
+    {
+        await GameManager.Connected(responseStream, context.CancellationToken);
+    }
+
+
+    public override async Task<UpdateResponse> PlayerUpdate(Player request, ServerCallContext context)
+    {
+        // Note 2024-05-01: as of now we don't handle authentication. 
+        // We're assuming that the update is coming from the actual player.
+        if (!_pm.Contains(request.Name))
+        {
+            _pm.AddPlayer(request);
+        }
+        else
+        {
+            _pm.Update(request);
+        }
+
+        await Task.Delay(500);
+
+        return new UpdateResponse();
+    }
+
+}

--- a/src/gRPC_MMO/server/ProximitySync/Services/ProximityServiceV2.cs
+++ b/src/gRPC_MMO/server/ProximitySync/Services/ProximityServiceV2.cs
@@ -7,13 +7,12 @@ using ProximitySync.Services.V2;
 namespace ProximitySync.Services;
 
 
-public class ProximityServiceV2(ILogger<ProximityService> logger) : ProximityUpdater.ProximityUpdaterBase
+public class ProximityServiceV2(ILogger<ProximityService> logger, IPlayerManager _pm, GameManager _gm) : ProximityUpdater.ProximityUpdaterBase
 {
-    private readonly PlayerManager _pm = PlayerManager.Instance;
-
+    
     public override async Task UpdatePlayers(Empty request, IServerStreamWriter<Players> responseStream, ServerCallContext context)
     {
-        await GameManager.Connected(responseStream, context.CancellationToken);
+        await _gm.Connected(responseStream, context.CancellationToken);
     }
 
 

--- a/src/gRPC_MMO/server/ProximitySync/Services/V2/GameManager.cs
+++ b/src/gRPC_MMO/server/ProximitySync/Services/V2/GameManager.cs
@@ -1,4 +1,4 @@
-using Grpc.Core;
+﻿using Grpc.Core;
 using ProximitySync.Data;
 using System.Collections.Concurrent;
 using System.ComponentModel.Design;
@@ -116,12 +116,9 @@ namespace ProximitySync.Services.V2
                     if (connection.Cancellation.IsCancellationRequested)
                     {
                         connectionsToRemove.Add(connection);
-                        return;
+                        continue;
                     }
-                    else
-                    {
-                        await connection.ResponseStream.WriteAsync(players);
-                    }
+                    await connection.ResponseStream.WriteAsync(players);
                 }
 
                 foreach (var connection in connectionsToRemove)

--- a/src/gRPC_MMO/server/ProximitySync/Services/V2/GameManager.cs
+++ b/src/gRPC_MMO/server/ProximitySync/Services/V2/GameManager.cs
@@ -1,0 +1,134 @@
+﻿using Grpc.Core;
+using ProximitySync.Data;
+using System.Collections.Concurrent;
+using System.ComponentModel.Design;
+using System.Runtime.CompilerServices;
+
+namespace ProximitySync.Services.V2
+{
+
+    /// <summary>
+    /// Main purpose for this class is to test the performance of using multiple threads to write the response to clients.
+    /// </summary>
+    public static class GameManager
+    {
+        private static readonly TimeSpan deltaTarget = TimeSpan.FromMicroseconds(500);
+        private static readonly UpdateWorker[] updateWorkers = new UpdateWorker[5];
+
+        private static int nextUpdateWorkerIndexToAddTo = 0;
+
+
+        static GameManager()
+        {
+            for (int i = 0; i < updateWorkers.Length; i++)
+            {
+                updateWorkers[i] = new UpdateWorker(deltaTarget);
+            }
+        }
+
+        public static Task Connected(IServerStreamWriter<Players> responseStream, CancellationToken cancellation)
+        {
+            var index = Interlocked.Increment(ref nextUpdateWorkerIndexToAddTo) - 1;
+            Console.WriteLine(index);
+            return updateWorkers[index % updateWorkers.Length].AddConnection(responseStream, cancellation);
+        }
+
+
+
+        private class UpdateWorker
+        {
+            private readonly List<ClientInfo> connections = [];
+            private readonly List<ClientInfo> connectionsToRemove = [];
+            private readonly object connectionsToAddLock = new();
+            private readonly List<ClientInfo> connectionsToAdd = [];
+            private readonly TimeSpan deltaTarget;
+
+            public UpdateWorker(TimeSpan deltaTarget)
+            {
+                this.deltaTarget = deltaTarget;
+                Thread gameLoop = new(async () => await ProcessQueue());
+                gameLoop.Start();
+            }
+
+
+
+            /// <summary>
+            ///  Await this so the connection won't get disconnected.
+            /// </summary>
+            public Task AddConnection(IServerStreamWriter<Players> responseStream, CancellationToken cancellation)
+            {
+                var connection = new ClientInfo(responseStream, cancellation);
+                lock (connectionsToAddLock)
+                {
+                    connectionsToAdd.Add(connection);
+                }
+                return connection.TaskCompletionSource.Task;
+            }
+
+
+
+            private async Task ProcessQueue()
+            {
+                DateTime lastUpdate = DateTime.Now;
+                TimeSpan delta;
+                while (true)
+                {
+                    delta = deltaTarget - (DateTime.Now - lastUpdate);
+                    lastUpdate = DateTime.Now;
+                    if (delta > TimeSpan.Zero)
+                    {
+                        Thread.Sleep(delta);
+                    }
+                    try
+                    {
+                        await UpdateClients();
+                    }
+                    catch (Exception) { }
+                }
+            }
+
+            private async Task UpdateClients()
+            {
+                lock (connectionsToAddLock)
+                {
+                    foreach (var connection in connectionsToAdd)
+                    {
+                        connections.Add(connection);
+                    }
+                    connectionsToAdd.Clear();
+                }
+
+                foreach(var connection in connections)
+                {
+                    var players = new Players();
+                    players.Players_.AddRange(PlayerManager.Instance.GetPlayers());
+                    if (connection.Cancellation.IsCancellationRequested)
+                    {
+                        connectionsToRemove.Add(connection);
+                        connection.TaskCompletionSource.SetResult();
+                        return;
+                    }
+                    await connection.ResponseStream.WriteAsync(players);
+                }
+
+                foreach(var connection in connectionsToRemove)
+                {
+                    connections.Remove(connection);
+                }
+
+                connectionsToRemove.Clear();
+            }
+        }
+
+
+
+        //public ClientInfo()
+        //{
+        //    TaskCompletionSource = new TaskCompletionSource();
+        //}
+        public readonly record struct ClientInfo(IServerStreamWriter<Players> ResponseStream, CancellationToken Cancellation)
+        {
+            public TaskCompletionSource TaskCompletionSource { get; } = new();
+        }
+    }
+}

--- a/src/gRPC_MMO/server/ProximitySync/Services/V2/GameManager.cs
+++ b/src/gRPC_MMO/server/ProximitySync/Services/V2/GameManager.cs
@@ -113,11 +113,15 @@ namespace ProximitySync.Services.V2
                         connection.TaskCompletionSource.SetResult();
                         return;
                     }
-                    await connection.ResponseStream.WriteAsync(players);
+                    else
+                    {
+                        await connection.ResponseStream.WriteAsync(players);
+                    }
                 }
 
                 foreach(var connection in connectionsToRemove)
                 {
+                    connection.TaskCompletionSource.SetResult();
                     connections.Remove(connection);
                 }
 

--- a/src/gRPC_MMO/server/ProximitySync/Services/V2/GameManager.cs
+++ b/src/gRPC_MMO/server/ProximitySync/Services/V2/GameManager.cs
@@ -33,6 +33,7 @@ namespace ProximitySync.Services.V2
         {
             var count = Interlocked.Increment(ref nextUpdateWorkerIndexToAddTo) - 1;
             var index = count % updateWorkers.Length;
+            Console.WriteLine($"added connection: {count}, to worker: #{index}");
             return updateWorkers[index].AddConnection(responseStream, cancellation);
         }
 

--- a/src/gRPC_MMO/server/ProximitySync/Services/V2/GameManager.cs
+++ b/src/gRPC_MMO/server/ProximitySync/Services/V2/GameManager.cs
@@ -1,4 +1,4 @@
-﻿using Grpc.Core;
+using Grpc.Core;
 using ProximitySync.Data;
 using System.Collections.Concurrent;
 using System.ComponentModel.Design;
@@ -13,7 +13,7 @@ namespace ProximitySync.Services.V2
     public class GameManager
     {
         private readonly IPlayerManager _pm;
-        private readonly TimeSpan deltaTarget = TimeSpan.FromMicroseconds(500);
+        private readonly TimeSpan deltaTarget = TimeSpan.FromMilliseconds(500);
         private readonly UpdateWorker[] updateWorkers = new UpdateWorker[5];
 
         private int nextUpdateWorkerIndexToAddTo = 0;

--- a/src/gRPC_MMO/server/ProximitySync/Services/V2/GameManager.cs
+++ b/src/gRPC_MMO/server/ProximitySync/Services/V2/GameManager.cs
@@ -13,7 +13,6 @@ namespace ProximitySync.Services.V2
     /// </summary>
     public class GameManager
     {
-        private readonly IPlayerManager _pm;
         private readonly TimeSpan deltaTarget = TimeSpan.FromMilliseconds(500);
         private readonly UpdateWorker[] updateWorkers = new UpdateWorker[5];
 
@@ -22,7 +21,6 @@ namespace ProximitySync.Services.V2
 
         public GameManager(IPlayerManager _pm, ILogger<GameManager> logger)
         {
-            this._pm = _pm;
             for (int i = 0; i < updateWorkers.Length; i++)
             {
                 updateWorkers[i] = new UpdateWorker(deltaTarget, _pm, logger);

--- a/src/gRPC_MMO/server/ProximitySync/Services/V2/GameManager.cs
+++ b/src/gRPC_MMO/server/ProximitySync/Services/V2/GameManager.cs
@@ -12,6 +12,8 @@ namespace ProximitySync.Services.V2
     /// </summary>
     public static class GameManager
     {
+        private static readonly PlayerManager _pm = PlayerManager.Instance;
+
         private static readonly TimeSpan deltaTarget = TimeSpan.FromMicroseconds(500);
         private static readonly UpdateWorker[] updateWorkers = new UpdateWorker[5];
 
@@ -101,7 +103,7 @@ namespace ProximitySync.Services.V2
                 foreach(var connection in connections)
                 {
                     var players = new Players();
-                    players.Players_.AddRange(PlayerManager.Instance.GetPlayers());
+                    players.Players_.AddRange(_pm.GetPlayers());
                     if (connection.Cancellation.IsCancellationRequested)
                     {
                         connectionsToRemove.Add(connection);

--- a/src/gRPC_MMO/tests/stress/ServerStressTest/GrpcClient.cs
+++ b/src/gRPC_MMO/tests/stress/ServerStressTest/GrpcClient.cs
@@ -46,7 +46,7 @@ internal class GrpcClient
                         {
                             DateTime t = DateTime.Now;
                             await _client.PlayerUpdateAsync(p);
-                            Console.WriteLine("Getting the update took: " + (DateTime.Now - t).TotalMilliseconds + " ms");
+                            Console.WriteLine("↑Pushing the update took: " + (DateTime.Now - t).TotalMilliseconds + " ms");
                         }
                         else
                         {

--- a/src/gRPC_MMO/tests/stress/ServerStressTest/GrpcClient.cs
+++ b/src/gRPC_MMO/tests/stress/ServerStressTest/GrpcClient.cs
@@ -1,3 +1,5 @@
+using System.Runtime.CompilerServices;
+using Google.Protobuf.WellKnownTypes;
 using Grpc.Core;
 using Grpc.Net.Client;
 using ProximitySync;
@@ -81,10 +83,16 @@ internal class GrpcClient
         Task.Run(async () =>
         {
             var positionUpdater = _client.UpdatePlayers(new Google.Protobuf.WellKnownTypes.Empty());
+            DateTime t = DateTime.Now;
             await foreach (var response in positionUpdater.ResponseStream.ReadAllAsync())
             {
                 try
                 {
+                    if(tracking)
+                    {
+                        Console.WriteLine("↓Getting the update took: " + (DateTime.Now - t).TotalMilliseconds + " ms; Received: " + response.Players_.Count);
+                        t = DateTime.Now;
+                    }
                     var r = response;
                     PlayersStateUpdated?.Invoke(r);
                 }

--- a/src/gRPC_MMO/tests/stress/ServerStressTest/Program.cs
+++ b/src/gRPC_MMO/tests/stress/ServerStressTest/Program.cs
@@ -2,7 +2,7 @@
 
 
 // -----------------------------------
-const int NUM_OF_CLIENTS = 200;
+const int NUM_OF_CLIENTS = 1000;
 const string ADDRESS = "https://localhost:7197";
 
 


### PR DESCRIPTION
### gRPC:
- Can handle ***1000*** connections with 1000 player update per connection at a server frame time of 500ms*, with concurrecy (concurrent dictionary):
   - ***500ms*** downstream and ***1500ms*** upstream
   - in debug could do ~250 instances.
   - ***700*** instances in release mode, at ***500ms***, were running without added delay.
- I hanven't noticed improvements in ustream throughput when running without concurrency, but the downstream was running at a better rate.
- Data: 
    - the 2D position data were saved as **double**, so **8+8 bytes**, 
    - about 8 char long **string** for name → at least **16 bytes**
    - => At least **32 bytes** were being sent for every player → **32MB** every frame

>[!Note]
> The server is not stable. Connection lost and other events are not properly handled.
